### PR TITLE
Fix typing_extension dependency at version 4.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ six
 humanize>=0.5
 dnspython>=2.2.0
 backports.functools-lru-cache>=1.6.4
+typing_extensions==4.1.1


### PR DESCRIPTION
Recent changes to yoda-clienttools and/or availability in PyPI lead to dependency problems.

At least on one CentOS 7 instance (lp0040) after creating a fresh virtualenv as specified in the README.txt leads to runtime (typing related) errors:

The versions of pip, virtualenv and PyPI lead to installation of typing-extensions version 4.3.0 which leads to an error. On Fedora 36 also with python3.6 (but of course much newer pip and virtualenv) this leads to typing-extensions version 4.1.1 . Manually installing this version (pip install typing-extensions==4.1.1) from within the venv makes the scripts workable again.

(venv) irods@lp0040 /var/lib/irods/yoda-clienttools /nluu10p/home/rods $ yimportgroups -h Traceback (most recent call last):
  File "/var/lib/irods/yoda-clienttools/venv/lib64/python3.6/site-packages/prettytable-3.4.1-py3.6.egg/prettytable/_init_.py", line 47, in <module>
    import importlib.metadata as importlib_metadata
ModuleNotFoundError: No module named 'importlib.metadata'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/lib/irods/yoda-clienttools/venv/lib64/python3.6/site-packages/importlib_metadata-5.0.0-py3.6.egg/importlib_metadata/_compat.py", line 9, in <module>
    from typing import Protocol
ImportError: cannot import name 'Protocol'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/lib/irods/yoda-clienttools/venv/bin/yimportgroups", line 11, in <module>
    load_entry_point('yclienttools==0.0.1', 'console_scripts', 'yimportgroups')()
  File "/var/lib/irods/yoda-clienttools/venv/lib64/python3.6/site-packages/pkg_resources/_init_.py", line 565, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/var/lib/irods/yoda-clienttools/venv/lib64/python3.6/site-packages/pkg_resources/_init_.py", line 2631, in load_entry_point
    return ep.load()
  File "/var/lib/irods/yoda-clienttools/venv/lib64/python3.6/site-packages/pkg_resources/_init_.py", line 2291, in load
    return self.resolve()
  File "/var/lib/irods/yoda-clienttools/venv/lib64/python3.6/site-packages/pkg_resources/_init_.py", line 2297, in resolve
    module = _import_(self.module_name, fromlist=['__name__'], level=0)
  File "/var/lib/irods/yoda-clienttools/venv/lib64/python3.6/site-packages/yclienttools-0.0.1-py3.6.egg/yclienttools/importgroups.py", line 14, in <module>
    from yclienttools import session as s
  File "/var/lib/irods/yoda-clienttools/venv/lib64/python3.6/site-packages/yclienttools-0.0.1-py3.6.egg/yclienttools/session.py", line 6, in <module>
    from irods.session import iRODSSession
  File "/var/lib/irods/yoda-clienttools/venv/lib64/python3.6/site-packages/python_irodsclient-1.1.1-py3.6.egg/irods/session.py", line 6, in <module>
    from irods.query import Query
  File "/var/lib/irods/yoda-clienttools/venv/lib64/python3.6/site-packages/python_irodsclient-1.1.1-py3.6.egg/irods/query.py", line 13, in <module>
    from irods.results import ResultSet, SpecificQueryResultSet
  File "/var/lib/irods/yoda-clienttools/venv/lib64/python3.6/site-packages/python_irodsclient-1.1.1-py3.6.egg/irods/results.py", line 2, in <module>
    from prettytable import PrettyTable
  File "/var/lib/irods/yoda-clienttools/venv/lib64/python3.6/site-packages/prettytable-3.4.1-py3.6.egg/prettytable/_init_.py", line 50, in <module>
    import importlib_metadata
  File "/var/lib/irods/yoda-clienttools/venv/lib64/python3.6/site-packages/importlib_metadata-5.0.0-py3.6.egg/importlib_metadata/_init_.py", line 17, in <module>
    from . import _adapters, _meta, _py39compat
  File "/var/lib/irods/yoda-clienttools/venv/lib64/python3.6/site-packages/importlib_metadata-5.0.0-py3.6.egg/importlib_metadata/_meta.py", line 1, in <module>
    from ._compat import Protocol
  File "/var/lib/irods/yoda-clienttools/venv/lib64/python3.6/site-packages/importlib_metadata-5.0.0-py3.6.egg/importlib_metadata/_compat.py", line 12, in <module>
    from typing_extensions import Protocol  # type: ignore
  File "/var/lib/irods/yoda-clienttools/venv/lib64/python3.6/site-packages/typing_extensions-4.3.0-py3.6.egg/typing_extensions.py", line 160, in <module>
    class _FinalForm(typing._SpecialForm, _root=True):
AttributeError: module 'typing' has no attribute '_SpecialForm'