### PR TITLE
YDA-5578: add duplicate group check

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ python_irodsclient==1.1.1
 enum34
 six
 humanize>=0.5
+iteration_utilities==0.11.0
 dnspython>=2.2.0
 backports.functools-lru-cache>=1.6.4
 typing_extensions==4.1.1

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
         'enum34',
         'six',
         'humanize>=0.5',
+        'iteration_utilities==0.11.0',
         'dnspython>=2.2.0',
         'backports.functools-lru-cache>=1.6.4',
         'PyYaml'

--- a/unit-tests/files/no-duplicates.csv
+++ b/unit-tests/files/no-duplicates.csv
@@ -1,0 +1,3 @@
+category,subcategory,groupname,manager
+test-automation,initial,groupteama,m.manager@yoda.dev
+test-automation,initial,groupteamb,m.manager@yoda.dev

--- a/unit-tests/files/with-duplicates.csv
+++ b/unit-tests/files/with-duplicates.csv
@@ -1,0 +1,5 @@
+category,subcategory,groupname,manager
+test-automation,initial,groupteama,m.manager@yoda.dev
+test-automation,initial,groupteamb,m.manager@yoda.dev
+test-automation,initial,data-duplicate,m.manager@yoda.dev
+test-automation,initial,data-duplicate,m.manager@yoda.dev

--- a/unit-tests/test_importgroups.py
+++ b/unit-tests/test_importgroups.py
@@ -13,7 +13,7 @@ from io import StringIO
 
 sys.path.append("../yclienttools")
 
-from importgroups import _get_duplicate_columns, _process_csv_line, parse_csv_file
+from importgroups import _get_duplicate_columns, _get_duplicate_groups, _process_csv_line, parse_csv_file
 
 
 class ImportGroupsTest(TestCase):
@@ -139,3 +139,12 @@ class ImportGroupsTest(TestCase):
         # csv that has too many items in the rows compared to the headers
         with self.assertRaises(SystemExit):
             parse_csv_file("files/more-entries-than-headers.csv", args, "1.9")
+
+    def test_parse_duplicate_groups(self):
+        args = {"offline_check": True}
+
+        data_no_duplicates = parse_csv_file("files/no-duplicates.csv", args, "1.9")
+        self.assertEqual(_get_duplicate_groups(data_no_duplicates), [])
+
+        data_with_duplicates = parse_csv_file("files/with-duplicates.csv", args, "1.9")
+        self.assertEqual(_get_duplicate_groups(data_with_duplicates), ["research-data-duplicate"])

--- a/yclienttools/importgroups.py
+++ b/yclienttools/importgroups.py
@@ -3,6 +3,8 @@ import argparse
 import csv
 import sys
 
+from iteration_utilities import duplicates, unique_everseen
+
 from yclienttools import common_args, common_config
 
 from yclienttools import session as s
@@ -108,6 +110,11 @@ def _get_duplicate_columns(fields_list, yoda_version):
                 fields_seen.add(field)
 
     return duplicate_fields
+
+
+def _get_duplicate_groups(row_data):
+    group_names = list(map(lambda r: r[2], row_data))
+    return list(unique_everseen(duplicates(group_names)))
 
 
 def _process_csv_line(line, args, yoda_version):
@@ -386,6 +393,11 @@ def entry():
     if (args.creator_user and (yoda_version in ('1.7', '1.8'))):
         _exit_with_error(
             "The --creator-user and --creator-zone options are only supported with Yoda versions 1.9 and higher.")
+
+    duplicate_groups = _get_duplicate_groups(data)
+    if duplicate_groups:
+        _exit_with_error(
+            "The group list has multiple rows with the same group name(s): " + ",".join(duplicate_groups))
 
     if args.offline_check:
         sys.exit(0)


### PR DESCRIPTION
Verify that CSV file does not have duplicate group names, since this can result in unexpected errors while importing (e.g. trying to create a group that has already been created earlier during the import).