### PR TITLE
Yda 5682 fix fails nonexistent domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 - Importgroups: fix issue where domain validation was not performed even if it had not been disabled
+- Importgroups: fix issue where username validation results were not processed correctly.
 
 ## 2024-04-18 v1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## UNRELEASED
+
+- Importgroups: fix issue where domain validation was not performed even if it had not been disabled
+
 ## 2024-04-18 v1.1.1
 
 - Fix regression that broke the ensuremembers tool

--- a/unit-tests/files/windows-csv.csv
+++ b/unit-tests/files/windows-csv.csv
@@ -1,3 +1,3 @@
 ﻿category,subcategory,groupname,manager,member,schema_id
-testcsv,testcsv,csvupload1,manager,member,default-3
-testcsv,testcsv,csvupload2,manager,member,default-3
+testcsv,testcsv,csvupload1,manager@example.com,member@example.com,default-3
+testcsv,testcsv,csvupload2,manager@example.com,member@example.com,default-3

--- a/unit-tests/test_importgroups.py
+++ b/unit-tests/test_importgroups.py
@@ -6,10 +6,11 @@
 __copyright__ = 'Copyright (c) 2019-2024, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
+import argparse
+from io import StringIO
 import sys
 from unittest import TestCase
 from unittest.mock import patch
-from io import StringIO
 
 sys.path.append("../yclienttools")
 
@@ -23,7 +24,7 @@ class ImportGroupsTest(TestCase):
         self.assertSetEqual(result, set({"category"}))
 
     def test_fully_filled_csv_line_1_9(self):
-        args = {"offline_check": True}
+        args = {"offline_check": True, "no_validate_domains": True}
         d = {
             "category": ["test-automation"],
             "subcategory": ["initial"],
@@ -44,12 +45,12 @@ class ImportGroupsTest(TestCase):
             "default-3",
             "2030-01-01",
         )
-        result, error_msg = _process_csv_line(d, args, "1.9")
+        result, error_msg = _process_csv_line(d, argparse.Namespace(**args), "1.9")
         self.assertTupleEqual(expected, result)
         self.assertIsNone(error_msg)
 
     def test_fully_filled_csv_line_1_9_multi_role(self):
-        args = {"offline_check": True}
+        args = {"offline_check": True, "no_validate_domains": True}
         d = {
             "category": ["test-automation"],
             "subcategory": ["initial"],
@@ -70,13 +71,13 @@ class ImportGroupsTest(TestCase):
             "default-3",
             "2030-01-01",
         )
-        result, error_msg = _process_csv_line(d, args, "1.9")
+        result, error_msg = _process_csv_line(d, argparse.Namespace(**args), "1.9")
         self.assertTupleEqual(expected, result)
         self.assertIsNone(error_msg)
 
     def test_fully_filled_csv_line_1_9_with_suffixes(self):
         # Confirm support the old csv header format still (with ":nicknameofuser")
-        args = {"offline_check": True}
+        args = {"offline_check": True, "no_validate_domains": True}
         d = {
             "category": ["test-automation"],
             "subcategory": ["initial"],
@@ -97,13 +98,13 @@ class ImportGroupsTest(TestCase):
             "default-3",
             "2030-01-01",
         )
-        result, error_msg = _process_csv_line(d, args, "1.9")
+        result, error_msg = _process_csv_line(d, argparse.Namespace(**args), "1.9")
         self.assertTupleEqual(expected, result)
         self.assertIsNone(error_msg)
 
     def test_fully_filled_csv_line_1_9_with_suffixes_multi_role(self):
         # Confirm support the old csv header format still (with ":nicknameofuser")
-        args = {"offline_check": True}
+        args = {"offline_check": True, "no_validate_domains": True}
         d = {
             "category": ["test-automation"],
             "subcategory": ["initial"],
@@ -127,12 +128,12 @@ class ImportGroupsTest(TestCase):
             "default-3",
             "2030-01-01",
         )
-        result, error_msg = _process_csv_line(d, args, "1.9")
+        result, error_msg = _process_csv_line(d, argparse.Namespace(**args), "1.9")
         self.assertTupleEqual(expected, result)
         self.assertIsNone(error_msg)
 
     def test_missing_fields_1_9(self):
-        args = {"offline_check": True}
+        args = {"offline_check": True, "no_validate_domains": True}
         # No schema id or expiration date
         d = {
             "category": ["test-automation"],
@@ -152,7 +153,7 @@ class ImportGroupsTest(TestCase):
             "",
             "",
         )
-        result, error_msg = _process_csv_line(d, args, "1.9")
+        result, error_msg = _process_csv_line(d, argparse.Namespace(**args), "1.9")
         self.assertTupleEqual(expected, result)
         self.assertIsNone(error_msg)
 
@@ -177,7 +178,7 @@ class ImportGroupsTest(TestCase):
             "",
             "",
         )
-        result, error_msg = _process_csv_line(d, args, "1.9")
+        result, error_msg = _process_csv_line(d, argparse.Namespace(**args), "1.9")
         self.assertTupleEqual(expected, result)
         self.assertIsNone(error_msg)
 
@@ -190,12 +191,12 @@ class ImportGroupsTest(TestCase):
             "expiration_date": ["2030-01-01"],
             "schema_id": ["default-3"],
         }
-        result, error_msg = _process_csv_line(d, args, "1.9")
+        result, error_msg = _process_csv_line(d, argparse.Namespace(**args), "1.9")
         self.assertIsNone(result)
         self.assertIn("missing", error_msg)
 
     def test_error_fields_1_8(self):
-        args = {"offline_check": True}
+        args = {"offline_check": True, "no_validate_domains": True}
         # Includes (valid) schema id and expiration,
         # which are not in version 1.8 (should give error)
         d = {
@@ -208,38 +209,38 @@ class ImportGroupsTest(TestCase):
             "schema_id": ["default-3"],
             "expiration_date": ["2030-01-01"],
         }
-        result, error_msg = _process_csv_line(d, args, "1.8")
+        result, error_msg = _process_csv_line(d, argparse.Namespace(**args), "1.8")
         self.assertIsNone(result)
         self.assertIn("1.9", error_msg)
 
     def test_parse_csv(self):
-        args = {"offline_check": True}
-        parse_csv_file("files/csv-import-test.csv", args, "1.9")
+        args = {"offline_check": True, "no_validate_domains": True}
+        parse_csv_file("files/csv-import-test.csv", argparse.Namespace(**args), "1.9")
 
         # With carriage returns
-        parse_csv_file("files/windows-csv.csv", args, "1.9")
+        parse_csv_file("files/windows-csv.csv", argparse.Namespace(**args), "1.9")
 
     @patch('sys.stderr', new_callable=StringIO)
     def test_parse_csv_with_header_suffixes(self, mock_stderr):
-        args = {"offline_check": True}
-        parse_csv_file("files/header-with-suffixes.csv", args, "1.8")
+        args = {"offline_check": True, "no_validate_domains": True}
+        parse_csv_file("files/header-with-suffixes.csv", argparse.Namespace(**args), "1.8")
 
     @patch('sys.stderr', new_callable=StringIO)
     def test_parse_invalid_csv_file(self, mock_stderr):
         # csv that has an unlabeled header
-        args = {"offline_check": True}
+        args = {"offline_check": True, "no_validate_domains": True}
         with self.assertRaises(SystemExit):
-            parse_csv_file("files/unlabeled-column.csv", args, "1.9")
+            parse_csv_file("files/unlabeled-column.csv", argparse.Namespace(**args), "1.9")
 
         # csv that has too many items in the rows compared to the headers
         with self.assertRaises(SystemExit):
-            parse_csv_file("files/more-entries-than-headers.csv", args, "1.9")
+            parse_csv_file("files/more-entries-than-headers.csv", argparse.Namespace(**args), "1.9")
 
     def test_parse_duplicate_groups(self):
-        args = {"offline_check": True}
+        args = {"offline_check": True, "no_validate_domains": True}
 
-        data_no_duplicates = parse_csv_file("files/no-duplicates.csv", args, "1.9")
+        data_no_duplicates = parse_csv_file("files/no-duplicates.csv", argparse.Namespace(**args), "1.9")
         self.assertEqual(_get_duplicate_groups(data_no_duplicates), [])
 
-        data_with_duplicates = parse_csv_file("files/with-duplicates.csv", args, "1.9")
+        data_with_duplicates = parse_csv_file("files/with-duplicates.csv", argparse.Namespace(**args), "1.9")
         self.assertEqual(_get_duplicate_groups(data_with_duplicates), ["research-data-duplicate"])

--- a/yclienttools/common_config.py
+++ b/yclienttools/common_config.py
@@ -2,25 +2,27 @@
     a config file, or if not defined a default value"""
 
 import os
+import sys
+from typing import Optional
 
 import yaml
 
 
-def get_ca_file():
+def get_ca_file() -> str:
     return _get_parameter_with_default(
         "ca_file", "/etc/irods/localhost_and_chain.crt")
 
 
-def get_default_yoda_version():
+def get_default_yoda_version() -> str:
     return str(_get_parameter_with_default("default_yoda_version", "1.8"))
 
 
-def _get_parameter_with_default(parameter, default_value):
+def _get_parameter_with_default(parameter: str, default_value: str) -> str:
     config_value = _get_parameter_from_config(parameter)
     return config_value if config_value is not None else default_value
 
 
-def _get_parameter_from_config(parameter):
+def _get_parameter_from_config(parameter: str) -> Optional[str]:
     config_filename = os.path.expanduser("~/.yodaclienttools.yml")
     if not os.path.exists(config_filename):
         return None
@@ -31,3 +33,4 @@ def _get_parameter_from_config(parameter):
         except yaml.YAMLError as e:
             print("Error occurred when opening configuration file.")
             print(e)
+            sys.exit(1)

--- a/yclienttools/common_rules.py
+++ b/yclienttools/common_rules.py
@@ -1,8 +1,8 @@
 '''This class is used as an interface for calling Yoda rules using python-irodsclient
 '''
 from io import StringIO
-
 from collections import OrderedDict
+from typing import List
 
 from irods.rule import Rule
 
@@ -27,7 +27,7 @@ Whether to specify the rule engine on rule calls
         self.default_rule_engine = 'irods_rule_engine_plugin-irods_rule_language-instance'
 
     def call_rule(self, rulename, params, number_outputs,
-                  rule_engine=None):
+                  rule_engine=None) -> List[str]:
         """Run a rule
 
            :param rulename: name of the rule
@@ -69,14 +69,14 @@ Whether to specify the rule engine on rule calls
 
         return buf[:number_outputs]
 
-    def _string_list_to_list(self, s):
+    def _string_list_to_list(self, s: str) -> List[str]:
         if s.startswith("[") and s.endswith("]"):
             return s[1:-1].split(",")
         else:
             raise ValueError(
                 "Unable to convert string representation of list to list")
 
-    def call_uuGroupGetMembers(self, groupname):
+    def call_uuGroupGetMembers(self, groupname: str) -> List[str]:
         """Returns list of group members"""
         parms = OrderedDict([
             ('groupname', groupname)])
@@ -86,14 +86,14 @@ Whether to specify the rule engine on rule calls
                 "Group member list exceeds 1023 bytes")
         return self._string_list_to_list(out)
 
-    def call_uuGroupUserRemove(self, groupname, user):
+    def call_uuGroupUserRemove(self, groupname: str, user: str) -> List[str]:
         """Removes a user from a group"""
         parms = OrderedDict([
             ('groupname', groupname),
             ('user', user)])
         return self.call_rule('uuGroupUserRemove', parms, 2)
 
-    def call_uuGroupGetMemberType(self, groupname, user):
+    def call_uuGroupGetMemberType(self, groupname: str, user: str) -> str:
         """:returns: member type of a group member"""
         parms = OrderedDict([
             ('groupname', groupname),
@@ -101,7 +101,7 @@ Whether to specify the rule engine on rule calls
         return self.call_rule('uuGroupGetMemberType', parms, 1)[0]
 
     def call_uuGroupUserAddByOtherCreator(
-            self, groupname, username, creator_user, creator_zone):
+            self, groupname: str, username: str, creator_user: str, creator_zone: str) -> List[str]:
         """Adds user to group on the behalf of a creator user.
 
            :param: groupname
@@ -117,7 +117,7 @@ Whether to specify the rule engine on rule calls
             ('creatorZone', creator_zone)])
         return self.call_rule('uuGroupUserAdd', parms, 2)
 
-    def call_uuGroupUserAdd(self, groupname, username):
+    def call_uuGroupUserAdd(self, groupname: str, username: str) -> List[str]:
         """Adds user to group.
 
            :param: groupname
@@ -129,7 +129,7 @@ Whether to specify the rule engine on rule calls
             ('username', username)])
         return self.call_rule('uuGroupUserAdd', parms, 2)
 
-    def call_uuGroupUserChangeRole(self, groupname, username, newrole):
+    def call_uuGroupUserChangeRole(self, groupname: str, username: str, newrole: str) -> List[str]:
         """Change role of user in group
 
            :param groupname: name of group
@@ -143,7 +143,7 @@ Whether to specify the rule engine on rule calls
             ('newrole', newrole)])
         return self.call_rule('uuGroupUserChangeRole', parms, 2)
 
-    def call_uuGroupExists(self, groupname):
+    def call_uuGroupExists(self, groupname: str) -> bool:
         """Check whether group name exists on Yoda
 
            :param groupname: name of group
@@ -153,7 +153,7 @@ Whether to specify the rule engine on rule calls
         [out] = self.call_rule('uuGroupExists', parms, 1)
         return out == 'true'
 
-    def call_uuUserExists(self, username):
+    def call_uuUserExists(self, username: str) -> bool:
         """Check whether user name exists on Yoda
 
            :param username: name of user
@@ -163,8 +163,8 @@ Whether to specify the rule engine on rule calls
         [out] = self.call_rule('uuUserExists', parms, 1)
         return out == 'true'
 
-    def call_uuGroupAdd(self, groupname, category,
-                        subcategory, description, classification, schema_id='default-2', expiration_date=''):
+    def call_uuGroupAdd(self, groupname: str, category: str,
+                        subcategory: str, description: str, classification, schema_id: str = 'default-2', expiration_date: str = '') -> List[str]:
         """Adds a group
 
            :param groupname: name of group
@@ -199,7 +199,7 @@ Whether to specify the rule engine on rule calls
 
         return self.call_rule('uuGroupAdd', parms, 2)
 
-    def call_uuGroupModify(self, groupname, property, value):
+    def call_uuGroupModify(self, groupname: str, property: str, value: str) -> List[str]:
         """Modifies one property of a group
 
            :param groupname: name of group
@@ -213,7 +213,7 @@ Whether to specify the rule engine on rule calls
                              ('value', value)])
         return self.call_rule('uuGroupModify', parms, 2)
 
-    def call_uuGroupRemove(self, groupname):
+    def call_uuGroupRemove(self, groupname: str) -> List[str]:
         """Removes an empty group
 
            :param groupname: name of group

--- a/yclienttools/importgroups.py
+++ b/yclienttools/importgroups.py
@@ -150,7 +150,7 @@ def _process_csv_line(line, args, yoda_version):
 
         for i in range(len(item_list)):
             item_list[i] = item_list[i].strip().lower()
-            is_valid = yoda_names.is_valid_username(item_list[i], args)
+            is_valid = yoda_names.is_valid_username(item_list[i], args.no_validate_domains)
             if not is_valid:
                 return None, '"{}" is not a valid username.'.format(item_list[i])
 

--- a/yclienttools/importgroups.py
+++ b/yclienttools/importgroups.py
@@ -151,9 +151,9 @@ def _process_csv_line(line: dict, args: argparse.Namespace, yoda_version: str) -
 
         for i in range(len(item_list)):
             item_list[i] = item_list[i].strip().lower()
-            is_valid = yoda_names.is_valid_username(item_list[i], args.no_validate_domains)
+            is_valid, validation_message = yoda_names.is_valid_username(item_list[i], args.no_validate_domains)
             if not is_valid:
-                return None, '"{}" is not a valid username.'.format(item_list[i])
+                return None, validation_message
 
         if column_name.lower() == 'manager' or column_name.lower().startswith('manager:'):
             managers.extend(item_list)

--- a/yclienttools/importgroups.py
+++ b/yclienttools/importgroups.py
@@ -2,6 +2,7 @@
 import argparse
 import csv
 import sys
+from typing import List, Set, Tuple
 
 from iteration_utilities import duplicates, unique_everseen
 
@@ -15,7 +16,7 @@ from yclienttools import yoda_names
 # Based on yoda-batch-add script by Ton Smeele
 
 
-def parse_csv_file(input_file, args, yoda_version):
+def parse_csv_file(input_file: str, args: argparse.Namespace, yoda_version: str) -> list:
     extracted_data = []
 
     with open(input_file, mode="r", encoding="utf-8-sig") as csv_file:
@@ -62,7 +63,7 @@ def parse_csv_file(input_file, args, yoda_version):
         # keys are the column names, items are the list of items
         for line in reader:
             row_number += 1
-            d = {}
+            d: dict = {}
             for j in range(len(line)):
                 item = line[j].strip()
                 if len(item):
@@ -82,30 +83,30 @@ def parse_csv_file(input_file, args, yoda_version):
     return extracted_data
 
 
-def _get_csv_possible_labels(yoda_version):
+def _get_csv_possible_labels(yoda_version: str) -> List[str]:
     if yoda_version in ('1.7', '1.8'):
         return ['category', 'subcategory', 'groupname', 'viewer', 'member', 'manager']
     else:
         return ['category', 'subcategory', 'groupname', 'viewer', 'member', 'manager', 'expiration_date', 'schema_id']
 
 
-def _get_csv_required_labels():
+def _get_csv_required_labels() -> List[str]:
     return ['category', 'subcategory', 'groupname']
 
 
-def _get_csv_1_9_exclusive_labels():
+def _get_csv_1_9_exclusive_labels() -> List[str]:
     """Returns labels that can only appear with yoda version 1.9 and higher."""
     return ['expiration_date', 'schema_id']
 
 
-def _get_csv_predefined_labels(yoda_version):
+def _get_csv_predefined_labels(yoda_version: str) -> List[str]:
     if yoda_version in ('1.7', '1.8'):
         return ['category', 'subcategory', 'groupname']
     else:
         return ['category', 'subcategory', 'groupname', 'expiration_date', 'schema_id']
 
 
-def _get_duplicate_columns(fields_list, yoda_version):
+def _get_duplicate_columns(fields_list: List[str], yoda_version: str) -> Set[str]:
     """ Only checks columns that cannot have duplicates """
     fields_seen = set()
     duplicate_fields = set()
@@ -120,12 +121,12 @@ def _get_duplicate_columns(fields_list, yoda_version):
     return duplicate_fields
 
 
-def _get_duplicate_groups(row_data):
+def _get_duplicate_groups(row_data: list) -> List[str]:
     group_names = list(map(lambda r: r[2], row_data))
     return list(unique_everseen(duplicates(group_names)))
 
 
-def _process_csv_line(line, args, yoda_version):
+def _process_csv_line(line: dict, args: argparse.Namespace, yoda_version: str) -> Tuple:
     if ('category' not in line or not len(line['category'])
             or 'subcategory' not in line or not len(line['subcategory'])
             or 'groupname' not in line or not len(line['groupname'])):
@@ -185,7 +186,7 @@ def _process_csv_line(line, args, yoda_version):
     return row_data, None
 
 
-def _are_roles_equivalent(a, b):
+def _are_roles_equivalent(a: str, b: str) -> bool:
     """Checks whether two roles are equivalent. Needed because Yoda and Yoda-clienttools
        use slightly different names for the roles."""
     r_role_names = ["viewer", "reader"]
@@ -201,7 +202,7 @@ def _are_roles_equivalent(a, b):
         return False
 
 
-def validate_data(rule_interface, args, data):
+def validate_data(rule_interface: RuleInterface, args: argparse.Namespace, data: list) -> List[str]:
     errors = []
     for (category, subcategory, groupname, managers, members, viewers, schema_id, expiration_date) in data:
         if rule_interface.call_uuGroupExists(groupname) and not args.allow_update:
@@ -219,7 +220,7 @@ def validate_data(rule_interface, args, data):
     return errors
 
 
-def apply_data(rule_interface, args, data):
+def apply_data(rule_interface: RuleInterface, args: argparse.Namespace, data: list) -> None:
     for (category, subcategory, groupname, managers, members, viewers, schema_id, expiration_date) in data:
         new_group = False
 
@@ -361,7 +362,7 @@ def apply_data(rule_interface, args, data):
                         print("Status: {} , Message: {}".format(status, msg))
 
 
-def print_parsed_data(data):
+def print_parsed_data(data: list) -> None:
     print('Parsed data:')
     print()
 
@@ -381,7 +382,7 @@ def print_parsed_data(data):
             print()
 
 
-def entry():
+def entry() -> None:
     '''Entry point'''
     args = _get_args()
     yoda_version = args.yoda_version if args.yoda_version is not None else common_config.get_default_yoda_version()
@@ -429,7 +430,7 @@ def entry():
         session.cleanup()
 
 
-def _get_args():
+def _get_args() -> argparse.Namespace:
     '''Parse command line arguments'''
 
     parser = argparse.ArgumentParser(
@@ -460,7 +461,7 @@ def _get_args():
     return parser.parse_args()
 
 
-def _get_format_help_text():
+def _get_format_help_text() -> str:
     return '''
         The CSV file is expected to include the following labels in its header (the first row):
         'category'        = category for the group
@@ -493,12 +494,12 @@ def _get_format_help_text():
     '''
 
 
-def _exit_with_error(message):
+def _exit_with_error(message: str) -> None:
     print("Error: {}".format(message), file=sys.stderr)
     sys.exit(1)
 
 
-def _exit_with_validation_errors(errors):
+def _exit_with_validation_errors(errors: List[str]) -> None:
     for error in errors:
         print("Validation error: {}".format(error), file=sys.stderr)
     sys.exit(1)

--- a/yclienttools/yoda_names.py
+++ b/yclienttools/yoda_names.py
@@ -8,6 +8,7 @@ __license__   = 'GPLv3, see LICENSE'
 
 import dns.resolver as resolver
 import re
+from typing import List, Optional, Tuple
 
 from datetime import datetime
 
@@ -17,7 +18,7 @@ except ImportError:
     from backports.functools_lru_cache import lru_cache  # type: ignore[no-redef]
 
 
-def is_valid_username(username, no_validate_domains):
+def is_valid_username(username: str, no_validate_domains: bool) -> Tuple[bool, Optional[str]]:
     """Is this name a valid username
     Returns whether valid and error
     """
@@ -33,32 +34,32 @@ def is_valid_username(username, no_validate_domains):
             ),
         )
     else:
-        return True
+        return True, None
 
 
-def is_email(username):
+def is_email(username: str) -> bool:
     return re.search(r"@.*[^\.]+\.[^\.]+$", username) is not None
 
 
 @lru_cache(maxsize=100)
-def is_valid_domain(domain):
+def is_valid_domain(domain: str) -> bool:
     try:
         return bool(resolver.query(domain, "MX"))
     except (resolver.NXDOMAIN, resolver.NoAnswer):
         return False
 
 
-def is_valid_category(name):
+def is_valid_category(name: str) -> bool:
     """Is this name a valid (sub)category name?"""
     return re.search(r"^[a-zA-Z0-9\-_]+$", name) is not None
 
 
-def is_valid_groupname(name):
+def is_valid_groupname(name: str) -> bool:
     """Is this name a valid group name (prefix such as "research-" can be omitted)"""
     return re.search(r"^[a-zA-Z0-9\-]+$", name) is not None
 
 
-def is_internal_user(username, internal_domains):
+def is_internal_user(username: str, internal_domains: List[str]) -> bool:
     for domain in internal_domains:
         domain_pattern = "@{}$".format(domain)
         if re.search(domain_pattern, username) is not None:
@@ -67,7 +68,7 @@ def is_internal_user(username, internal_domains):
     return False
 
 
-def is_valid_expiration_date(expiration_date):
+def is_valid_expiration_date(expiration_date: str) -> bool:
     """Validation of expiration date.
 
     :param expiration_date: String containing date that has to be validated
@@ -92,7 +93,7 @@ def is_valid_expiration_date(expiration_date):
         return False
 
 
-def is_valid_schema_id(schema_id):
+def is_valid_schema_id(schema_id: str) -> bool:
     """Is this schema at least a correctly formatted schema-id?"""
     if schema_id == "":
         return True


### PR DESCRIPTION
This PR fixes two typing issues related to the importgroups user name validation.

It also adjusts some of the importgroups unit tests, so that they are compatible with the fixed validation code, and adds type annotations in order to reduce the risk of future typing-related bugs in this part of the code.