### PR TITLE
YDA-5953 uuUserExists with rule_user_exists

### DIFF
--- a/yclienttools/common_rules.py
+++ b/yclienttools/common_rules.py
@@ -17,7 +17,7 @@ class RuleInterface:
            :param session: IrodsSession object to call
            :param yoda_version: which Yoda version to assume (e.g. 1.7, 1.8, 1.9)
 
-Whether to specify the rule engine on rule calls
+            Whether to specify the rule engine on rule calls
                           (enable for Yoda 1.8 and higher, disable for Yoda 1.7)
         """
         self.session = session
@@ -164,11 +164,7 @@ Whether to specify the rule engine on rule calls
            :param username: name of user
            :returns: false/true
         """
-        # Ensure client_hints_rules initialized
-        if not hasattr(self, 'client_hints_rules') or not isinstance(self.client_hints_rules, list):
-            self.client_hints_rules = self.session.client_hints.get("rules", {})
-
-        # Determinie which rule to call
+        # Determine which rule to call
         rule_to_call = 'rule_user_exists' if 'rule_user_exists' in self.client_hints_rules else 'uuUserExists'
 
         # Prepare rule parameters

--- a/yclienttools/common_rules.py
+++ b/yclienttools/common_rules.py
@@ -16,6 +16,7 @@ class RuleInterface:
 
            :param session: IrodsSession object to call
            :param yoda_version: which Yoda version to assume (e.g. 1.7, 1.8, 1.9)
+
 Whether to specify the rule engine on rule calls
                           (enable for Yoda 1.8 and higher, disable for Yoda 1.7)
         """

--- a/yclienttools/common_rules.py
+++ b/yclienttools/common_rules.py
@@ -16,8 +16,7 @@ class RuleInterface:
 
            :param session: IrodsSession object to call
            :param yoda_version: which Yoda version to assume (e.g. 1.7, 1.8, 1.9)
-
-            Whether to specify the rule engine on rule calls
+Whether to specify the rule engine on rule calls
                           (enable for Yoda 1.8 and higher, disable for Yoda 1.7)
         """
         self.session = session

--- a/yclienttools/common_rules.py
+++ b/yclienttools/common_rules.py
@@ -153,14 +153,28 @@ Whether to specify the rule engine on rule calls
         [out] = self.call_rule('uuGroupExists', parms, 1)
         return out == 'true'
 
-    def call_uuUserExists(self, username: str) -> bool:
+    def call_rule_user_exists(self, username: str) -> bool:
         """Check whether user name exists on Yoda
 
            :param username: name of user
            :returns: false/true
         """
+
+        # Attempt to retrieve client hints rules
+        try:
+            client_hints_rules = self.session.client_hints.get("rules", {})
+        except Exception as e:
+            print("Error: {}. Hint: python-irodsclient needs to be version 2.1 or later to support client_hints.".format(e))
+
+        # Select python rule if avaliable, otherwise select legacy rule
+        rule_to_call = 'rule_user_exists' if 'rule_user_exists' in client_hints_rules else 'uuUserExists'
         parms = OrderedDict([('username', username)])
-        [out] = self.call_rule('uuUserExists', parms, 1)
+        if rule_to_call == 'rule_user_exists':
+            parms['outparam1'] = ""
+
+        # Call the rule
+        [out] = self.call_rule(rule_to_call, parms, 1)
+
         return out == 'true'
 
     def call_uuGroupAdd(self, groupname: str, category: str,

--- a/yclienttools/ensuremembers.py
+++ b/yclienttools/ensuremembers.py
@@ -60,7 +60,7 @@ def validate_data(rule_interface, args, userdata, groupdata):
 
     for user in userdata:
         if not is_internal_user(user, args.internal_domains.split(",")):
-            if not rule_interface.call_uuUserExists(user):
+            if not rule_interface.call_rule_user_exists(user):
                 errors.append("External user {} does not exist.".format(user))
 
     for group in groupdata:

--- a/yclienttools/importgroups.py
+++ b/yclienttools/importgroups.py
@@ -213,7 +213,7 @@ def validate_data(rule_interface: RuleInterface, args: argparse.Namespace, data:
                 # ensure that external users already have an iRODS account
                 # we do not want to be the actor that creates them (unless
                 # we are creating them in the name of a creator user)
-                if not rule_interface.call_uuUserExists(user) and not args.creator_user:
+                if not rule_interface.call_rule_user_exists(user) and not args.creator_user:
                     errors.append(
                         'Group {} has nonexisting external user {}'.format(groupname, user))
 

--- a/yclienttools/rmusers.py
+++ b/yclienttools/rmusers.py
@@ -39,7 +39,7 @@ def validate_data(session, rule_interface, args, userdata):
     errors = []
 
     for user in userdata:
-        if not rule_interface.call_uuUserExists(user):
+        if not rule_interface.call_rule_user_exists(user):
             errors.append(f"User {user} does not exist.")
         if home_exists(session, user) and not home_is_empty(session, user):
             errors.append(f"Home directory of user {user} is not empty")


### PR DESCRIPTION
1. Tested with `rule_interface.call_rule_user_exists(user)` for either case of rule_user_exists and uuUserExists. (running make and make install are required to update the rule base)
2. Suggest to test the rule_user_exists based on the branch (if not merged to development): https://github.com/UtrechtUniversity/yoda-ruleset/pull/516