### PR TITLE
YDA-6035: add revision data to GLC report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## UNRELEASED
+
+- Add revision statistics to the group lifecycle report. Size of research group in this report
+  no longer includes revisions.
+
 ## 2024-11-21 v1.5.0
 
 - Add some default values for the CA file location that also work in non-Yoda-server environments.

--- a/README.md
+++ b/README.md
@@ -374,18 +374,18 @@ expiration date (if available), lists of group managers, regular members, and
 readonly members. The report also shows whether each research compartment
 contains data, as well as whether its vault compartment contains data. The
 report can optionally include size and last modified date of both the research
-and vault collection.
+and vault collection, as well as revisions.
 
 optional arguments:
   -h, --help            show this help message and exit
   -q, --quasi-xml       Enable Quasi-XML parser in order to be able to parse
                         characters not supported by regular XML parser
-  -s, --size            Include size of research collection and vault
-                        collection in output
+  -s, --size            Include size of research collection, vault collection
+                        and revisions in output
   -H, --human-readable  Report sizes in human-readable figures (only relevant
                         in combination with --size parameter)
-  -m, --modified        Include last modified date research collection and
-                        vault collection in output
+  -m, --modified        Include last modified date research collection,
+                        revisions and vault collection in output
   -y {1.7,1.8,1.9,1.10}, --yoda-version {1.7,1.8,1.9,1.10}
                         Override Yoda version on the server
 ```


### PR DESCRIPTION
Optionally add data about the size of revisions of the research group, as well as last modification date of revisions, to the group lifecycle report.

Size of research group no longer includes revisions.