### PR TITLE
YDA-6020: extended data package report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Data package status report: report data package collections with no valid status
   correctly.
 - Add "all" option for --internal-domains in ensuremembers and importgroups tool
+- Data packages report: report information for all data packages regarding path, size,
+  publication state and date, README file, license, access type, metadata schema.
 
 ## 2024-12-24 v1.8.0
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,23 @@ OK
 
 ## Overview of tools
 
+### yreport\_datapackageinfo
+
+Shows an extended data package report of each data package in the vault.
+
+```
+usage: yreport_datapackageinfo [-y {1.7,1.8,1.9,1.10}] [--help] [-h]
+
+Shows an extended data package report of each data package in the vault.
+
+options:
+  -y {1.7,1.8,1.9,1.10}, --yoda-version {1.7,1.8,1.9,1.10}
+                        Override Yoda version on the server
+  --help                show help information
+  -h, --human-readable  Show sizes in human readable format, e.g. 1.0MB
+                        instead of 1000000
+```
+
 ### ycleanup\_files
 
 ```

--- a/README.md
+++ b/README.md
@@ -87,12 +87,16 @@ OK
 
 ### yreport\_datapackageinfo
 
-Shows an extended data package report of each data package in the vault.
+Shows an extended data package report for each data package in the vault that includes
+path, size, publication status and date, README file, license, data access type, and
+metadata schema. The output is in CSV format.
 
 ```
 usage: yreport_datapackageinfo [-y {1.7,1.8,1.9,1.10}] [--help] [-h]
 
-Shows an extended data package report of each data package in the vault.
+Shows an extended data package report for each data package in the vault that includes
+path, size, publication status and date, README file, license, data access type, and
+metadata schema. The output is in CSV format.
 
 options:
   -y {1.7,1.8,1.9,1.10}, --yoda-version {1.7,1.8,1.9,1.10}

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     packages=['yclienttools'],
     entry_points={
         'console_scripts': [
+            'yreport_datapackageinfo= yclienttools.reportdatapackageinfo:entry',
             'yreport_dataobjectspercollection= yclienttools.reportdoc:entry',
             'yreport_datapackagestatus= yclienttools.reportdatapackagestatus:entry',
             'yreport_collectionsize= yclienttools.reportsize:entry',

--- a/yclienttools/reportdatapackageinfo.py
+++ b/yclienttools/reportdatapackageinfo.py
@@ -1,0 +1,135 @@
+import argparse
+import sys
+import csv
+import humanize
+from urllib.parse import urlparse
+from irods.column import Like
+from irods.models import Collection, CollectionMeta
+from yclienttools import common_args, common_config, common_queries, common_file_ops
+from yclienttools import session as s
+from yclienttools.options import GroupByOption
+
+def entry():
+    '''Entry point'''
+    try:
+        args = _get_args()
+        yoda_version = args.yoda_version if args.yoda_version is not None else common_config.get_default_yoda_version()
+        session = s.setup_session(yoda_version)
+
+        data_package_report(args, session)
+        session.cleanup()
+
+    except KeyboardInterrupt:
+        print("Script interrupted by user.\n", file=sys.stderr)
+
+
+def _get_args():
+    '''Parse command line arguments'''
+    parser = argparse.ArgumentParser(description=__doc__, add_help=False)
+    common_args.add_default_args(parser)
+    parser.add_argument('--help', action='help', help='show help information')
+    parser.add_argument('-h', '--human-readable', action='store_true', default=False,
+                        help="Show sizes in human readable format, e.g. 1.0MB instead of 1000000")
+    return parser.parse_args()
+
+
+def data_package_report(args, session):
+    output = csv.writer(sys.stdout, delimiter=',')
+    for data_package in _get_data_packages(session):
+        _get_package_info(output, session, data_package, args.human_readable)
+
+
+def _get_package_info(csv_output, session, collection, human_readable):
+    raw_size = common_queries.get_collection_size(session, collection, True, GroupByOption.none, False)['all']
+    vault_status = _get_vault_status(session, collection)
+    publication_date = _get_publication_date(session, collection)  
+    has_readme = _has_readme_file(session, collection) 
+    license = _get_license(session, collection)
+    data_access = _get_data_access(session, collection)    
+    metadata_schema = _get_metadata_schema(session, collection)    
+    
+    if human_readable:
+        display_size = str(humanize.naturalsize(raw_size))
+    else:
+        display_size = str(raw_size)
+
+    csv_output.writerow([collection, display_size, vault_status, publication_date, has_readme, license, data_access, metadata_schema])
+
+def _get_data_packages(session):
+    """Returns a list of collections of all data packages."""
+    query_results = session.query(Collection.name).filter(
+        Like(Collection.parent_name, '/%/home/vault-%')).get_results()
+
+    return [result[Collection.name]
+            for result in query_results if not result[Collection.name].endswith("/original")]
+    
+
+def _get_vault_status(session, collection):
+    """Returns vault status of data package (or None if not found)."""
+    query_results = list(session.query(CollectionMeta.value).filter(
+        Collection.name == collection).filter(
+        CollectionMeta.name == 'org_vault_status').get_results())
+
+    if len(query_results) == 1:
+        return query_results[0][CollectionMeta.value]
+    else:
+        return None
+
+
+def _get_publication_date(session, collection):
+    """Returns publication date of data package (or None if not found)."""
+    query_results = list(session.query(CollectionMeta.value).filter(
+        Collection.name == collection).filter(
+        CollectionMeta.name == 'org_publication_publicationDate').get_results())
+
+    if len(query_results) == 1:
+        return query_results[0][CollectionMeta.value]
+    else:
+        return None
+
+
+def _has_readme_file(session, collection):
+    """Returns True if data package contains a README file, otherwise False."""
+    for data_obj in common_queries.get_dataobjects_in_collection(session, collection):
+        if "readme" in data_obj.lower():
+            return True
+
+    return False        
+
+
+def _get_license(session, collection):
+    """Returns license of data package (or None if not found)."""
+    query_results = list(session.query(CollectionMeta.value).filter(
+        Collection.name == collection).filter(
+        CollectionMeta.name == 'License').get_results())
+
+    if len(query_results) == 1:
+        return query_results[0][CollectionMeta.value]
+    else:
+        return None
+
+
+def _get_data_access(session, collection):
+    """Returns data access type of data package (or None if not found)."""
+    query_results = list(session.query(CollectionMeta.value).filter(
+        Collection.name == collection).filter(
+        CollectionMeta.name == 'Data_Access_Restriction').get_results())
+
+    if len(query_results) == 1:
+        return query_results[0][CollectionMeta.value]
+    else:
+        return None
+
+
+def _get_metadata_schema(session, collection):
+    """Returns metadata schema of data package (or None if not found)."""
+    query_results = list(session.query(CollectionMeta.value).filter(
+        Collection.name == collection).filter(
+        CollectionMeta.name == 'href').get_results())
+
+    if len(query_results) == 1:
+        href = query_results[0][CollectionMeta.value]
+        href_parts = urlparse(href).path.split('/')
+        return href_parts[-2]
+    else:
+        return None

--- a/yclienttools/reportdatapackageinfo.py
+++ b/yclienttools/reportdatapackageinfo.py
@@ -36,7 +36,9 @@ def _get_args():
 
 def data_package_report(args, session):
     output = csv.writer(sys.stdout, delimiter=',')
-    for data_package in _get_data_packages(session):
+    output.writerow(["Path", "Size", "Publication status", "Publication date", "Has README file", "License type", "Data access type", "Metadata schema"])
+
+    for data_package in common_queries.get_vault_data_packages(session):
         _get_package_info(output, session, data_package, args.human_readable)
 
 
@@ -45,7 +47,7 @@ def _get_package_info(csv_output, session, collection, human_readable):
     vault_status = _get_vault_status(session, collection)
     publication_date = _get_publication_date(session, collection)
     has_readme = _has_readme_file(session, collection)
-    license = _get_license(session, collection)
+    license_type = _get_license(session, collection)
     data_access = _get_data_access(session, collection)
     metadata_schema = _get_metadata_schema(session, collection)
 
@@ -54,16 +56,7 @@ def _get_package_info(csv_output, session, collection, human_readable):
     else:
         display_size = str(raw_size)
 
-    csv_output.writerow([collection, display_size, vault_status, publication_date, has_readme, license, data_access, metadata_schema])
-
-
-def _get_data_packages(session):
-    """Returns a list of collections of all data packages."""
-    query_results = session.query(Collection.name).filter(
-        Like(Collection.parent_name, '/%/home/vault-%')).get_results()
-
-    return [result[Collection.name]
-            for result in query_results if not result[Collection.name].endswith("/original")]
+    csv_output.writerow([collection, display_size, vault_status, publication_date, has_readme, license_type, data_access, metadata_schema])
 
 
 def _get_vault_status(session, collection):

--- a/yclienttools/reportdatapackageinfo.py
+++ b/yclienttools/reportdatapackageinfo.py
@@ -5,9 +5,10 @@ import humanize
 from urllib.parse import urlparse
 from irods.column import Like
 from irods.models import Collection, CollectionMeta
-from yclienttools import common_args, common_config, common_queries, common_file_ops
+from yclienttools import common_args, common_config, common_queries
 from yclienttools import session as s
 from yclienttools.options import GroupByOption
+
 
 def entry():
     '''Entry point'''
@@ -42,18 +43,19 @@ def data_package_report(args, session):
 def _get_package_info(csv_output, session, collection, human_readable):
     raw_size = common_queries.get_collection_size(session, collection, True, GroupByOption.none, False)['all']
     vault_status = _get_vault_status(session, collection)
-    publication_date = _get_publication_date(session, collection)  
-    has_readme = _has_readme_file(session, collection) 
+    publication_date = _get_publication_date(session, collection)
+    has_readme = _has_readme_file(session, collection)
     license = _get_license(session, collection)
-    data_access = _get_data_access(session, collection)    
-    metadata_schema = _get_metadata_schema(session, collection)    
-    
+    data_access = _get_data_access(session, collection)
+    metadata_schema = _get_metadata_schema(session, collection)
+
     if human_readable:
         display_size = str(humanize.naturalsize(raw_size))
     else:
         display_size = str(raw_size)
 
     csv_output.writerow([collection, display_size, vault_status, publication_date, has_readme, license, data_access, metadata_schema])
+
 
 def _get_data_packages(session):
     """Returns a list of collections of all data packages."""
@@ -62,7 +64,7 @@ def _get_data_packages(session):
 
     return [result[Collection.name]
             for result in query_results if not result[Collection.name].endswith("/original")]
-    
+
 
 def _get_vault_status(session, collection):
     """Returns vault status of data package (or None if not found)."""
@@ -72,8 +74,8 @@ def _get_vault_status(session, collection):
 
     if len(query_results) == 1:
         return query_results[0][CollectionMeta.value]
-    else:
-        return None
+
+    return None
 
 
 def _get_publication_date(session, collection):
@@ -84,8 +86,8 @@ def _get_publication_date(session, collection):
 
     if len(query_results) == 1:
         return query_results[0][CollectionMeta.value]
-    else:
-        return None
+
+    return None
 
 
 def _has_readme_file(session, collection):
@@ -94,7 +96,7 @@ def _has_readme_file(session, collection):
         if "readme" in data_obj.lower():
             return True
 
-    return False        
+    return False
 
 
 def _get_license(session, collection):
@@ -105,8 +107,8 @@ def _get_license(session, collection):
 
     if len(query_results) == 1:
         return query_results[0][CollectionMeta.value]
-    else:
-        return None
+
+    return None
 
 
 def _get_data_access(session, collection):
@@ -117,8 +119,8 @@ def _get_data_access(session, collection):
 
     if len(query_results) == 1:
         return query_results[0][CollectionMeta.value]
-    else:
-        return None
+
+    return None
 
 
 def _get_metadata_schema(session, collection):
@@ -131,5 +133,5 @@ def _get_metadata_schema(session, collection):
         href = query_results[0][CollectionMeta.value]
         href_parts = urlparse(href).path.split('/')
         return href_parts[-2]
-    else:
-        return None
+
+    return None

--- a/yclienttools/reportdatapackageinfo.py
+++ b/yclienttools/reportdatapackageinfo.py
@@ -3,7 +3,6 @@ import sys
 import csv
 import humanize
 from urllib.parse import urlparse
-from irods.column import Like
 from irods.models import Collection, CollectionMeta
 from yclienttools import common_args, common_config, common_queries
 from yclienttools import session as s

--- a/yclienttools/reportdatapackageinfo.py
+++ b/yclienttools/reportdatapackageinfo.py
@@ -1,3 +1,8 @@
+'''Shows an extended data package report for each data package in the vault that includes
+   path, size, publication status and date, README file, license, data access type, and
+   metadata schema. The output is in CSV format.
+'''
+
 import argparse
 import sys
 import csv


### PR DESCRIPTION
This branch adds a new extended report which returns specific information regarding data packages in the vault:
- Path
- Size
- Publication state
- Publication date (if applicable)
- Does it have a README file?
- License
- Data package access type
- Metadata schema