### PR TITLE
YDA-6217: fix CA certificate autodetection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   Yoda 2.0.
 - Docs: update example expiration date for importgroups - it needs to be in the future.
   Also update metadata schema in example to latest version.
+- Fix autodetection of CA certificates by choosing the iRODS server certificate over
+  the distribution CA certificates, if available, so that running the client tools on a
+  (development) server with a self-signed certificate works as expected with default
+  settings.
 
 ## 2025-02-17 v1.9.0
 

--- a/yclienttools/common_config.py
+++ b/yclienttools/common_config.py
@@ -11,9 +11,9 @@ import yaml
 def get_ca_file() -> str:
     configured_ca_file = _get_parameter_from_config("ca_file")
     if configured_ca_file is None:
-        for standard_location in ["/etc/ssl/certs/ca-certificates.crt",
-                                  "/etc/pki/tls/certs/ca-bundle.crt",
-                                  "/etc/irods/localhost_and_chain.crt"]:
+        for standard_location in ["/etc/irods/localhost_and_chain.crt",
+                                  "/etc/ssl/certs/ca-certificates.crt",
+                                  "/etc/pki/tls/certs/ca-bundle.crt"]:
             if os.path.isfile(standard_location):
                 return standard_location
 


### PR DESCRIPTION
Fix autodetection of CA certificates by choosing the iRODS server certificate over the distribution CA certificates, if available, so that running the client tools on a (development) server with a self-signed certificate works as expected with default settings.