### PR TITLE
YDA-6931: group add support for Yoda 2.1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## UNRELEASED
 
-- Drop support for Yoda 1.8, 1.9 and 1.10
-- Add support for Yoda 2.1 (excluding support for importgroups and recatgroups,
-  which will be added shortly)
+- Drop support for Yoda 1.8.x, 1.9.x and 1.10.x
+- Add support for Yoda 2.1.x
 - Update yoda group, category and subcategory name verification logic
   so that it matches with the Yoda design documentation.
 - Migrate mypy and flake configuration from setup.cfg to pyproject.toml

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ usage: yimportgroups [-h] [-y {2.0,2.1}] -i INTERNAL_DOMAINS
                      [--offline-check | --online-check] [--allow-update]
                      [--delete] [--verbose] [--no-validate-domains]
                      [--creator-user CREATOR_USER]
-                     [--creator-zone CREATOR_ZONE]
+                     [--creator-zone CREATOR_ZONE] [--create-sram-co]
                      csvfile
 
 Creates a list of groups based on a CSV file
@@ -258,8 +258,7 @@ options:
   -y {2.0,2.1}, --yoda-version {2.0,2.1}
                         Override Yoda version on the server
   -i INTERNAL_DOMAINS, --internal-domains INTERNAL_DOMAINS
-                        Comma-separated list of internal email domains to the Yoda server, or "all"
-                        if all domains should be considered internal
+                        Comma-separated list of internal email domains to the Yoda server, or "all" if all domains should be considered internal
   --offline-check, -c   Check mode (offline): verify CSV format only. Does not connect to iRODS and does not create groups
   --online-check, -C    Check mode (online): verify CSV format and that groups do not exist. Does not create groups.
   --allow-update, -u    Allows existing groups to be updated
@@ -271,6 +270,7 @@ options:
                         User who creates user
   --creator-zone CREATOR_ZONE
                         Zone of the user who creates user
+  --create-sram-co      Create SRAM CO for new groups (only available on Yoda 2.1+)
 
         The CSV file is expected to include the following labels in its header (the first row):
         'category'        = category for the group
@@ -300,7 +300,6 @@ options:
         category,subcategory,groupname,manager,member,expiration_date,schema_id
         departmentx,teama,groupteama,m.manager@example.com,m.member@example.com,2055-01-01,default-3
         departmentx,teamb,groupteamb,m.manager@example.com,p.member@example.com,,
-
 ```
 
 ### yexportgroups
@@ -341,8 +340,9 @@ options:
 Bulk (sub)category changes for Yoda research groups.
 
 ```
-usage: yrecatgroups [-h] [--check | --dry-run] --datamanagers-new-category
-                    DATAMANAGERS_NEW_CATEGORY [--verbose]
+usage: yrecatgroups [-h] [-y {2.0,2.1}] [--check | --dry-run]
+                    --datamanagers-new-category DATAMANAGERS_NEW_CATEGORY
+                    [--create-sram-co] [--verbose]
                     csvfile
 
 Bulk (sub)category changes for Yoda research groups.
@@ -352,6 +352,8 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
+  -y {2.0,2.1}, --yoda-version {2.0,2.1}
+                        Override Yoda version on the server
   --check, -c           Check mode: verify CSV format and content.
   --dry-run, -d         Dry-run mode: connects to iRODS, validates, and prints what would change. Does not modify any groups.
   --datamanagers-new-category DATAMANAGERS_NEW_CATEGORY, --datamagers-new-category DATAMANAGERS_NEW_CATEGORY
@@ -359,6 +361,7 @@ options:
                         Use an empty string ("") to explicitly allow creating new categories without datamanagers.
                         Example: --datamanagers-new-category 'dm1@example.org;dm2@example.org'
                         Example (no DMs): --datamanagers-new-category ''
+  --create-sram-co      Create SRAM CO for new groups (only available on Yoda 2.1+)
   --verbose, -v         Verbose output.
 
         The CSV file is expected to include the following labels in its header (the first row):

--- a/yclienttools/common_rules.py
+++ b/yclienttools/common_rules.py
@@ -18,7 +18,10 @@ class RuleInterface:
            :param yoda_version: which Yoda version to assume (e.g. 2.0, 2.1)
         """
         self.session = session
-        self.uuGroupAdd_version = "1.9"
+        if yoda_version == "2.0":
+            self.uuGroupAdd_version = "2.0"
+        else:
+            self.uuGroupAdd_version = "2.1"
         self.default_rule_engine = 'irods_rule_engine_plugin-irods_rule_language-instance'
 
         try:
@@ -171,8 +174,15 @@ class RuleInterface:
 
         return out == 'true'
 
-    def call_uuGroupAdd(self, groupname: str, category: str,
-                        subcategory: str, description: str, classification, schema_id: str = 'default-2', expiration_date: str = '') -> List[str]:
+    def call_uuGroupAdd(self,
+                        groupname: str,
+                        category: str,
+                        subcategory: str,
+                        description: str,
+                        classification,
+                        schema_id: str = 'default-2',
+                        expiration_date: str = '',
+                        sram_co: bool = False) -> List[str]:
         """Adds a group
 
            :param groupname: name of group
@@ -182,13 +192,14 @@ class RuleInterface:
            :param classification: security classification
            :param schema_id: schema id
            :param expiration_date: expiration date
+           :param sram_co: create SRAM CO (True/False) - only available on Yoda 2.1+
 
            :raises Exception: for unsupported Yoda version
 
            :returns: (status, message). Status not 0 means error,
                      -1089000 means group name already exists
         """
-        if self.uuGroupAdd_version == "1.9":
+        if self.uuGroupAdd_version == "2.0":
             parms = OrderedDict([
                 ('groupname', groupname),
                 ('category', category),
@@ -198,6 +209,18 @@ class RuleInterface:
                 ('description', description),
                 ('dataClassification', classification),
                 ('co_identifier', '')
+            ])
+        elif self.uuGroupAdd_version == "2.1":
+            parms = OrderedDict([
+                ('groupname', groupname),
+                ('category', category),
+                ('subcategory', subcategory),
+                ('schema_id', schema_id if schema_id not in ("", ".") else "default-2"),
+                ('expiration_date', expiration_date),
+                ('description', description),
+                ('dataClassification', classification),
+                ('co_identifier', ''),
+                ('sram_co', str(sram_co))
             ])
         else:
             raise Exception("Unsupported Yoda version")

--- a/yclienttools/importgroups.py
+++ b/yclienttools/importgroups.py
@@ -202,7 +202,14 @@ def apply_data(rule_interface: RuleInterface, args: argparse.Namespace, data: li
         # First create the group. Note that the rodsadmin actor will become a
         # groupmanager.
         [status, msg] = rule_interface.call_uuGroupAdd(
-            groupname, category, subcategory, '', 'unspecified', schema_id, expiration_date)
+            groupname,
+            category,
+            subcategory,
+            '',
+            'unspecified',
+            schema_id,
+            expiration_date,
+            args.create_sram_co)
 
         if ((status in '-1089000', '-809000', '-806000')) and args.allow_update:
             print(
@@ -427,6 +434,8 @@ def _get_args() -> argparse.Namespace:
                         help='User who creates user')
     parser.add_argument('--creator-zone', type=str,
                         help='Zone of the user who creates user')
+    parser.add_argument('--create-sram-co', action='store_true', default=False,
+                        help='Create SRAM CO for new groups (only available on Yoda 2.1+)')
     return parser.parse_args()
 
 

--- a/yclienttools/recatgroups.py
+++ b/yclienttools/recatgroups.py
@@ -9,7 +9,7 @@ from typing import List, Sequence, Set, Tuple, Type
 
 from irods.models import Group, User, UserMeta
 
-from yclienttools import common_config, common_queries, yoda_names
+from yclienttools import common_args, common_config, common_queries, yoda_names
 from yclienttools.common_queries import collection_exists
 from yclienttools import session as s
 from yclienttools.common_rules import RuleInterface
@@ -22,7 +22,7 @@ from yclienttools.common_rules import RuleInterface
 def entry() -> None:
     """Entry point."""
     args = _get_args()
-    yoda_version = common_config.get_default_yoda_version()
+    yoda_version = args.yoda_version if args.yoda_version is not None else common_config.get_default_yoda_version()
 
     # -datamanagers_new_category is required, can be empty string => empty list
     args.datamanagers_new_category = _split_datamanagers(args.datamanagers_new_category)
@@ -65,6 +65,7 @@ def _get_args() -> argparse.Namespace:
         epilog=_get_format_help_text(),
         formatter_class=argparse.RawTextHelpFormatter,
     )
+    common_args.add_default_args(parser)
 
     parser.add_argument("csvfile", help="CSV file containing recategorization records.")
 
@@ -91,7 +92,8 @@ def _get_args() -> argparse.Namespace:
             "Example (no DMs): --datamanagers-new-category ''"
         ),
     )
-
+    parser.add_argument('--create-sram-co', action='store_true', default=False,
+                        help='Create SRAM CO for new groups (only available on Yoda 2.1+)')
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output.")
     return parser.parse_args()
 
@@ -513,6 +515,7 @@ def _ensure_datamanager_group_exists(
         data_classification,
         schema_id,
         expiration_date,
+        args.create_sram_co
     )
 
     if status in _ALREADY_EXISTS_CODES:


### PR DESCRIPTION
In Yoda v2.1.x, we have an additional parameter when adding groups that controls whether an SRAM CO will be created. This adds a command-line parameter to provide that configuration value to the tools that add groups, so that these tools support Yoda v2.1.x